### PR TITLE
Add social urls to footer links

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -29,15 +29,15 @@ export default function Footer({ pages, page: currentPage }) {
       </section>
 
       <section className={classNames(styles.social, styles.links)}>
-        <a href="#instagram">
+        <a href="https://www.instagram.com/alchemycodelab/">
           <span>Instagram</span>
         </a>
 
-        <a href="#twitter">
+        <a href="https://twitter.com/AlchemyCodeLab">
           <span>Twitter</span>
         </a>
 
-        <a href="#facebook">
+        <a href="https://www.facebook.com/AlchemyCodeLab">
           <span>Facebook</span>
         </a>
       </section>


### PR DESCRIPTION
None of the links to socials in the footer had hrefs. I chose not to open the links in a new tab because there are other external links on the website that open in the same tab.